### PR TITLE
Enable 4.1.20 in prerelease channel(s)

### DIFF
--- a/channels/prerelease-4.2.yaml
+++ b/channels/prerelease-4.2.yaml
@@ -1,5 +1,7 @@
 name: prerelease-4.2
 versions:
+- 4.1.20
+
 - 4.2.0-rc.0
 - 4.2.0-rc.1
 - 4.2.0-rc.5


### PR DESCRIPTION
Please merge immediately. This PR does not need to wait for an advisory to ship, but the associated advisory is https://errata.devel.redhat.com/advisory/123413 .

This PR will also enable upgrades from 4.1.20 to releases in prerelease-4.2