### PR TITLE
Enable 4.6.21 in fast channel(s)

### DIFF
--- a/channels/fast-4.6.yaml
+++ b/channels/fast-4.6.yaml
@@ -1,0 +1,4 @@
+name: fast-4.6
+versions:
+
+- 4.6.21


### PR DESCRIPTION
Please merge as soon as https://errata.devel.redhat.com/advisory/123413 is shipped live OR if a Cincinnati-first release is approved.